### PR TITLE
bug fixed

### DIFF
--- a/src/features/vacancies/components/VacancyApplicationsModal.tsx
+++ b/src/features/vacancies/components/VacancyApplicationsModal.tsx
@@ -14,7 +14,7 @@ import {
   useDeleteApplication,
   VacancyResponseDto,
 } from '@/query/vacancies/use-vacancies'
-import { Download, ExternalLink, Mail, MapPin, Phone, Trash2 } from 'lucide-react'
+import { Download, ExternalLink, Mail, MapPin, Trash2 } from 'lucide-react'
 import { VacancyAnswer } from '@/schemas/vacancy'
 import {
   Select,
@@ -127,9 +127,6 @@ export const VacancyApplicationsModal: FC<VacancyApplicationsModalProps> = ({
                         <span className='flex items-center gap-1'>
                           <Mail className='h-3.5 w-3.5' /> {app.email}
                         </span>
-                        <span className='flex items-center gap-1'>
-                          <Phone className='h-3.5 w-3.5' /> {app.contact}
-                        </span>
                         {app.currentAddress && (
                           <span className='flex items-center gap-1'>
                             <MapPin className='h-3.5 w-3.5' /> {app.currentAddress}
@@ -183,15 +180,6 @@ export const VacancyApplicationsModal: FC<VacancyApplicationsModalProps> = ({
                     </div>
                   )}
 
-                  {app.message && (
-                    <div className='rounded bg-muted/40 p-3 text-xs text-foreground/90'>
-                      <span className='font-semibold'>Message / Cover Letter:</span>
-                      <p className='mt-1 whitespace-pre-wrap leading-relaxed'>
-                        {app.message}
-                      </p>
-                    </div>
-                  )}
-
                   <div className='flex flex-wrap items-center justify-between gap-2 pt-2 text-xs text-muted-foreground'>
                     <span>
                       Applied on: {new Date(app.createdAt).toLocaleDateString()}
@@ -211,7 +199,7 @@ export const VacancyApplicationsModal: FC<VacancyApplicationsModalProps> = ({
                             rel='noreferrer'
                             download
                           >
-                            <Download className='h-3.5 w-3.5' /> View CV
+                            <Download className='h-3.5 w-3.5' /> View CV / Resume
                             <ExternalLink className='h-3 w-3 ml-0.5' />
                           </a>
                         </Button>

--- a/src/features/vacancies/components/VacancyApplyModal.tsx
+++ b/src/features/vacancies/components/VacancyApplyModal.tsx
@@ -30,19 +30,9 @@ import {
   VacancyResponseDto,
 } from '@/query/vacancies/use-vacancies'
 import { Badge } from '@/ui/shadcn/badge'
-import {
-  Briefcase,
-  Calendar,
-  Clock,
-  MapPin,
-  Upload,
-  FileCheck,
-} from 'lucide-react'
+import { Briefcase, Calendar, Clock, MapPin } from 'lucide-react'
 import { useGetIkAuthParams } from '@/query/imagekit/use-ik'
 import { getIkAuthParams } from '@/query/imagekit/ik-service'
-import IKContext from '@/ui/molecules/image-kit/IKContext'
-import IKUpload from '@/ui/molecules/image-kit/IKUpload'
-import { toast } from '@/hooks/use-toast'
 import { DynamicQuestionField } from './DynamicQuestionField'
 
 interface VacancyApplyModalProps {
@@ -51,15 +41,13 @@ interface VacancyApplyModalProps {
   onOpenChange: (open: boolean) => void
 }
 
-const CV_UPLOAD_ID = 'cv-upload'
-
 export const VacancyApplyModal: FC<VacancyApplyModalProps> = ({
   vacancy,
   open,
   onOpenChange,
 }) => {
   const applyMutation = useApplyVacancy()
-  // Tracks which uploader (CV or a FILE question) is currently busy.
+  // Tracks which FILE question uploader is currently busy.
   const [uploadingId, setUploadingId] = useState<string | null>(null)
 
   // The list endpoint may return a trimmed vacancy, so pull the full record
@@ -76,13 +64,11 @@ export const VacancyApplyModal: FC<VacancyApplyModalProps> = ({
   const emptyValues = useMemo<VacancyApplyFormValues>(
     () => ({
       fullName: '',
+      currentAddress: '',
       email: '',
       confirmEmail: '',
-      contact: '',
-      currentAddress: '',
-      cvUrl: '',
-      cvFileId: '',
       answers: buildDefaultAnswers(questions),
+      cvUrl: '',
     }),
     [questions]
   )
@@ -99,7 +85,7 @@ export const VacancyApplyModal: FC<VacancyApplyModalProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, vacancy?.id, emptyValues])
 
-  // ImageKit credentials
+  // ImageKit credentials — used only by FILE-type questions.
   const { data: ikData } = useGetIkAuthParams()
   const endpoint = ikData?.data?.endpoint
   const publicKey = ikData?.data?.publicKey
@@ -232,7 +218,7 @@ export const VacancyApplyModal: FC<VacancyApplyModalProps> = ({
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>
-                        Full Name <span className='text-red-500'>*</span>
+                        Name <span className='text-red-500'>*</span>
                       </FormLabel>
                       <FormControl>
                         <Input {...field} />
@@ -244,14 +230,14 @@ export const VacancyApplyModal: FC<VacancyApplyModalProps> = ({
 
                 <FormField
                   control={form.control}
-                  name='contact'
+                  name='currentAddress'
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>
-                        Contact Number <span className='text-red-500'>*</span>
+                        Current Address <span className='text-red-500'>*</span>
                       </FormLabel>
                       <FormControl>
-                        <Input placeholder='+977 98XXXXXXXX' {...field} />
+                        <Input placeholder='City, Country' {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -297,118 +283,6 @@ export const VacancyApplyModal: FC<VacancyApplyModalProps> = ({
                 />
               </div>
 
-              <FormField
-                control={form.control}
-                name='currentAddress'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      Current Address <span className='text-red-500'>*</span>
-                    </FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* CV Upload */}
-              <FormField
-                control={form.control}
-                name='cvUrl'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      Link to CV <span className='text-red-500'>*</span>{' '}
-                      (PDF/DOCX/Doc)
-                    </FormLabel>
-                    <FormControl>
-                      <div className='rounded-lg border-2 border-dashed border-border bg-muted/30 p-4'>
-                        <IKContext
-                          publicKey={publicKey}
-                          urlEndpoint={endpoint}
-                          authenticator={authenticator}
-                        >
-                          <div className='flex flex-col items-center gap-2 text-center'>
-                            {field.value ? (
-                              <div className='flex items-center gap-2 text-sm font-medium text-emerald-600'>
-                                <FileCheck className='h-5 w-5' />
-                                <span>CV Uploaded successfully</span>
-                                <Button
-                                  type='button'
-                                  variant='ghost'
-                                  size='sm'
-                                  className='h-auto p-1 text-xs text-destructive'
-                                  onClick={() => {
-                                    form.setValue('cvUrl', '')
-                                    form.setValue('cvFileId', '')
-                                  }}
-                                >
-                                  Remove
-                                </Button>
-                              </div>
-                            ) : (
-                              <>
-                                <Upload className='h-6 w-6 text-muted-foreground' />
-                                <span className='text-xs text-muted-foreground'>
-                                  Upload your CV (Max 10MB)
-                                </span>
-                                <IKUpload
-                                  inputId={CV_UPLOAD_ID}
-                                  isUploading={uploadingId === CV_UPLOAD_ID}
-                                  label='Select CV File'
-                                  description='CV file size should not exceed 10MB'
-                                  folder={folder}
-                                  useUniqueFileName={true}
-                                  onUploadStart={() =>
-                                    setUploadingId(CV_UPLOAD_ID)
-                                  }
-                                  onError={(err) => {
-                                    setUploadingId(null)
-                                    toast({
-                                      variant: 'destructive',
-                                      title: 'Upload failed',
-                                      description:
-                                        err?.message || 'Could not upload file.',
-                                    })
-                                  }}
-                                  onSuccess={(res: {
-                                    url?: string
-                                    fileId?: string
-                                  }) => {
-                                    setUploadingId(null)
-                                    if (res?.url) {
-                                      form.setValue('cvUrl', res.url)
-                                      if (res.fileId)
-                                        form.setValue('cvFileId', res.fileId)
-                                      toast({
-                                        title: 'CV uploaded',
-                                      })
-                                    }
-                                  }}
-                                />
-                              </>
-                            )}
-                          </div>
-                        </IKContext>
-                        {/* Fallback URL input option */}
-                        <div className='mt-3 border-t pt-3'>
-                          <Input
-                            type='url'
-                            placeholder='Or paste a direct CV URL (Google Drive/Dropbox)'
-                            value={field.value}
-                            onChange={(e) => field.onChange(e.target.value)}
-                            className='text-xs'
-                          />
-                        </div>
-                      </div>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
               {/* Role-specific questions */}
               {questions.length > 0 && (
                 <div className='space-y-4 border-t pt-6'>
@@ -437,6 +311,31 @@ export const VacancyApplyModal: FC<VacancyApplyModalProps> = ({
                   ))}
                 </div>
               )}
+
+              {/* Link to CV / Resume — always the last field */}
+              <FormField
+                control={form.control}
+                name='cvUrl'
+                render={({ field }) => (
+                  <FormItem className='border-t pt-6'>
+                    <FormLabel>
+                      Link to CV / Resume <span className='text-red-500'>*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type='url'
+                        placeholder='https://drive.google.com/...'
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription className='text-xs'>
+                      Paste a shareable link (Google Drive, Dropbox, OneDrive).
+                      Make sure the link is viewable by anyone.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
               <div className='flex justify-end gap-2 pt-4'>
                 <Button

--- a/src/features/vacancies/list/index.tsx
+++ b/src/features/vacancies/list/index.tsx
@@ -35,6 +35,8 @@ import {
   Calendar,
   ClipboardList,
 } from 'lucide-react'
+import { Main } from '@/ui/layouts/main'
+import PageHeader from '@/ui/page-header'
 import { VacancyApplyModal } from '../components/VacancyApplyModal'
 import { VacancyApplicationsModal } from '../components/VacancyApplicationsModal'
 import { ConfirmDialog } from '@/ui/confirm-dialog'
@@ -64,22 +66,19 @@ export const VacanciesList: FC = () => {
   }
 
   return (
-    <div className='p-6 space-y-6'>
-      {/* Page Header */}
-      <div className='flex flex-wrap items-center justify-between gap-4'>
-        <div>
-          <h1 className='text-2xl font-bold tracking-tight'>Vacancies & Careers</h1>
-          <p className='text-sm text-muted-foreground'>
-            Manage career opportunities, job postings, and review candidate applications.
-          </p>
-        </div>
-        <Button
-          onClick={() => navigate({ to: '/vacancies/add' })}
-          className='gap-2'
-        >
-          <Plus className='h-4 w-4' /> Add New Vacancy
-        </Button>
-      </div>
+    <Main className='flex flex-col gap-6'>
+      <PageHeader
+        title='Vacancies & Careers'
+        description='Manage career opportunities, job postings, and review candidate applications.'
+        actions={
+          <Button
+            onClick={() => navigate({ to: '/vacancies/add' })}
+            className='gap-2'
+          >
+            <Plus className='h-4 w-4' /> Add New Vacancy
+          </Button>
+        }
+      />
 
       {/* Toolbar */}
       <div className='flex flex-wrap items-center justify-between gap-4 rounded-lg border bg-card p-4 shadow-sm'>
@@ -95,7 +94,7 @@ export const VacanciesList: FC = () => {
       </div>
 
       {/* Table Content */}
-      <div className='rounded-lg border bg-card shadow-sm'>
+      <div className='overflow-x-auto rounded-lg border bg-card shadow-sm'>
         {isLoading ? (
           <div className='py-12 text-center text-muted-foreground'>
             Loading vacancies...
@@ -262,7 +261,7 @@ export const VacanciesList: FC = () => {
         destructive
         handleConfirm={handleDeleteConfirm}
       />
-    </div>
+    </Main>
   )
 }
 

--- a/src/features/vacancies/shared/ApplicationFormModal.tsx
+++ b/src/features/vacancies/shared/ApplicationFormModal.tsx
@@ -47,29 +47,17 @@ interface ApplicationFormModalProps extends BuilderProps {
   vacancyTitle?: string
 }
 
-/** Fields every applicant fills, regardless of the role. Not editable. */
+/** Fields every applicant fills before the role-specific questions. */
 const COMMON_FIELDS: {
   label: string
   placeholder: string
   type: string
   full?: boolean
 }[] = [
-  { label: 'Full Name', placeholder: 'Applicant full name', type: 'text' },
-  { label: 'Contact Number', placeholder: '+977 98XXXXXXXX', type: 'text' },
+  { label: 'Name', placeholder: 'Applicant full name', type: 'text' },
+  { label: 'Current Address', placeholder: 'City, Country', type: 'text' },
   { label: 'Email', placeholder: 'name@example.com', type: 'email' },
   { label: 'Confirm Email', placeholder: 'Re-enter email', type: 'email' },
-  {
-    label: 'Current Address',
-    placeholder: 'City, Country',
-    type: 'text',
-    full: true,
-  },
-  {
-    label: 'Link to CV',
-    placeholder: 'Upload or paste a CV link (PDF/DOCX/Doc)',
-    type: 'text',
-    full: true,
-  },
 ]
 
 const OptionsEditor: FC<BuilderProps & { index: number }> = ({
@@ -335,8 +323,9 @@ export const ApplicationFormModal: FC<ApplicationFormModalProps> = ({
           </DialogTitle>
           <DialogDescription>
             This is the form applicants fill in
-            {vacancyTitle ? ` for ${vacancyTitle}` : ''}. The common fields are
-            fixed — add role-specific questions below them.
+            {vacancyTitle ? ` for ${vacancyTitle}` : ''}, in order. The common
+            fields and the CV link are fixed — add role-specific questions in
+            between.
           </DialogDescription>
         </DialogHeader>
 
@@ -420,6 +409,34 @@ export const ApplicationFormModal: FC<ApplicationFormModalProps> = ({
               />
             ))
           )}
+        </div>
+
+        {/* Link to CV / Resume — always rendered last on the apply form */}
+        <div className='space-y-3 border-t pt-4'>
+          <div className='flex items-center gap-2'>
+            <Lock className='h-3.5 w-3.5 text-muted-foreground' />
+            <h4 className='text-sm font-semibold text-foreground'>
+              Link to CV / Resume
+            </h4>
+            <Badge variant='secondary' className='text-[10px]'>
+              Always last
+            </Badge>
+          </div>
+
+          <div className='rounded-lg border bg-muted/20 p-4'>
+            <label className='text-sm font-medium text-foreground'>
+              Link to CV / Resume <span className='text-red-500'>*</span>
+            </label>
+            <Input
+              type='url'
+              className='mt-1.5 cursor-not-allowed bg-background'
+              placeholder='https://drive.google.com/...'
+              disabled
+            />
+            <p className='mt-1.5 text-xs text-muted-foreground'>
+              Applicants paste a shareable Drive/Dropbox link — no file upload.
+            </p>
+          </div>
         </div>
 
         <DialogFooter className='border-t pt-4'>

--- a/src/features/vacancies/shared/VacancyForm.tsx
+++ b/src/features/vacancies/shared/VacancyForm.tsx
@@ -21,6 +21,7 @@ import {
   VacancyFormValues,
   VacancyQuestion,
 } from '@/schemas/vacancy'
+import { Main } from '@/ui/layouts/main'
 import { ApplicationFormModal } from './ApplicationFormModal'
 import { Badge } from '@/ui/shadcn/badge'
 import {
@@ -122,8 +123,8 @@ export const VacancyForm: FC<VacancyFormProps> = ({
   })
 
   return (
-    <div className='p-6 space-y-6 max-w-6xl mx-auto'>
-      <div className='flex items-center justify-between'>
+    <Main className='flex flex-col gap-6'>
+      <div className='flex flex-wrap items-center justify-between gap-4'>
         <div className='flex items-center gap-3'>
           <Button
             variant='outline'
@@ -468,8 +469,8 @@ export const VacancyForm: FC<VacancyFormProps> = ({
                         : `Common fields + ${questionCount} question${questionCount === 1 ? '' : 's'}`}
                     </p>
                     <p className='text-xs text-muted-foreground'>
-                      Full name, contact, email, confirm email, current address
-                      and link to CV are always asked.
+                      Name, current address, email and confirm email are asked
+                      first; the link to CV / resume is always asked last.
                     </p>
                   </div>
                 </div>
@@ -508,6 +509,6 @@ export const VacancyForm: FC<VacancyFormProps> = ({
           </div>
         </form>
       </Form>
-    </div>
+    </Main>
   )
 }

--- a/src/query/vacancies/use-vacancies.ts
+++ b/src/query/vacancies/use-vacancies.ts
@@ -14,13 +14,10 @@ export interface VacancyApplicationResponseDto {
   vacancyId: string
   fullName: string
   email: string
-  contact: string
   currentAddress?: string
-  /** Legacy free-text cover letter — no longer collected, still rendered if present. */
-  message?: string
   answers?: VacancyAnswer[]
+  /** Shareable link to the applicant's CV / resume. */
   cvUrl: string
-  cvFileId?: string
   status: string
   createdAt: string
   updatedAt: string

--- a/src/schemas/vacancy.ts
+++ b/src/schemas/vacancy.ts
@@ -121,15 +121,18 @@ export const vacancyAnswerSchema = z.object({
 
 export type VacancyAnswer = z.infer<typeof vacancyAnswerSchema>
 
+// Field order mirrors the apply form: name, address, email, confirm email,
+// role-specific answers, then the CV link last.
 const vacancyApplyBaseSchema = z.object({
   fullName: z.string().min(1, 'Full name is required'),
+  currentAddress: z.string().min(1, 'Current address is required'),
   email: z.string().email('Invalid email address'),
   confirmEmail: z.string().min(1, 'Please confirm your email'),
-  contact: z.string().min(1, 'Contact number is required'),
-  currentAddress: z.string().min(1, 'Current address is required'),
-  cvUrl: z.string().min(1, 'CV upload is required'),
-  cvFileId: z.string().optional().nullable(),
   answers: z.array(vacancyAnswerSchema).default([]),
+  cvUrl: z
+    .string()
+    .min(1, 'CV / Resume link is required')
+    .url('Enter a valid link (e.g. a Google Drive or Dropbox URL)'),
 })
 
 const isBlank = (value: VacancyAnswerValue) =>


### PR DESCRIPTION
### Summary
Fixes the broken page layout on the Vacancies screens, removes the unused
**Contact number** and **Message / Cover letter** fields, reorders the apply form
to the agreed sequence, and replaces the CV file uploader with a plain
Drive/Dropbox link field.

Also documents a **backend gap** that blocks the custom-questions feature end to
end (see "Known issue" below) — no frontend change can fix it.

### Changes

**Layout (`out of layout / no margin`)**
- The vacancy pages were the only feature in the app not wrapped in `<Main>`;
  they used a bare `<div className='p-6'>`, which sits outside the `<main>`
  element the `h-svh` flex layout sizes and scrolls.
- `list/index.tsx` and `shared/VacancyForm.tsx` now use `<Main>`, matching
  News / Projects / Events.
- The list header now uses the shared `PageHeader` component.
- The vacancies table wrapper got `overflow-x-auto`, so it scrolls inside its
  card instead of stretching the page.

**Apply form field order**
New order, applied consistently to the apply form, the CMS builder preview, and
the Zod schema:

`Name → Current Address → Email → Confirm Email → [CMS-added questions] → Link to CV / Resume`

**Removed fields**
- **Contact number** — removed from the apply form, the apply schema, and the
  applications list view.
- **Message / Cover letter** — removed from the applications view and from
  `VacancyApplicationResponseDto`.

**CV / Resume**
- The ImageKit uploader for the CV is gone; applicants now paste a shareable
  link (Google Drive / Dropbox / OneDrive), validated as a URL.
- `cvFileId` dropped
- The ImageKit uploader is retained for `FILE`-type custom questions.

**CMS builder preview (`ApplicationFormModal`)**
- Locked common fields updated to Name / Current Address / Email / Confirm Email.
- A locked "Link to CV / Resume — Always last" preview added *after* the
  questions list, so the preview matches the real applicant flow.
- Helper copy updated to describe the actual order.

### Known issue — needs backend work (not in this PR)

Custom questions added in the CMS still will not persist after this PR. The
frontend already sends `questions` in the create/update body, but the API drops
it:

GET /api/v1/vacancies/<id>
→ id, title, openings, duration, hoursPerWeek, overview, responsibilities,
  requirements, location, type, deadline, isActive, isDraft,
  createdAt, updatedAt, _count, deletedAt

server-side (NestJS `whitelist: true`). This is also why the questions never
appear on the public website.

Backend needs to add:
- `questions` on `Vacancy` (JSON column or relation), accepted in the create /
  update DTOs and returned in both list and detail responses.
  Item shape: `{ id, label, type, required, helpText, options[], order }`
  with `type ∈ TEXT | PARAGRAPH | SINGLE_CHOICE | MULTI_CHOICE | BOOLEAN | NUMBER | DATE | FILE | URL`
- `answers` on the application record, shape
  `{ questionId, label, type, value, fileId? }`

The frontend already reads and writes exactly these shapes, so the feature will
start working as soon as the API accepts them — no further CMS change required.

### ⚠️ Deploy note
If the apply endpoint's DTO still marks `contact` as required, submissions will
return **400** after this PR, since the CMS no longer sends it. `contact` must be
made optional or removed on the backend before/with this release.

### Testing
- `tsc --noEmit` — passes
- `eslint` on all touched files — passes
- Manual: vacancy list, add, and edit pages render with correct page padding and
  scroll; apply modal shows the new field order with the CV link last; questions
  render between Confirm Email and the CV link.

### Files changed
- `src/schemas/vacancy.ts`
- `src/features/vacancies/components/VacancyApplyModal.tsx`
- `src/features/vacancies/components/VacancyApplicationsModal.tsx`
- `src/features/vacancies/shared/ApplicationFormModal.tsx`
- `src/features/vacancies/shared/VacancyForm.tsx`
- `src/features/vacancies/list/index.tsx`
- `src/query/vacancies/use-vacancies.ts`
